### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,24 +143,25 @@ In addition to these three things, you may also include a help directory, which 
 Your model should work with the sample data provided and `run.sh`. If your model generates image-level predictions, it should include the following columns and be saved as a csv file.
 
 Image-level prediction
-image_index  |  malignant_pred  |  malignant_label
--------------|---------------|------------------
-0_L-CC       |  0.0081          |  0
-0_R-CC       |  0.3259          |  0
-0_L-MLO      |  0.0335          |  0
-0_R-MLO      |  0.1812          |  0
-1_L-CC       |  0.0168          |  0
-1_R-CC       |  0.9910          |  1
-1_L-MLO      |  0.0139          |  0
-1_R-MLO      |  0.9308          |  1
-2_L-CC       |  0.0227          |  0
-2_R-CC       |  0.0603          |  0
-2_L-MLO      |  0.0093          |  0
-2_R-MLO      |  0.0231          |  0
-3_L-CC       |  0.9326          |  1
-3_R-CC       |  0.1603          |  0
-3_L-MLO      |  0.7496          |  1
-3_R-MLO      |  0.0507          |  0
+
+| image_index  |  malignant_pred  |  malignant_label  |
+| ------------ | ---------------- | ----------------- |
+| 0_L-CC       |  0.0081          |  0                |
+| 0_R-CC       |  0.3259          |  0                |
+| 0_L-MLO      |  0.0335          |  0                |
+| 0_R-MLO      |  0.1812          |  0                |
+| 1_L-CC       |  0.0168          |  0                |
+| 1_R-CC       |  0.9910          |  1                |
+| 1_L-MLO      |  0.0139          |  0                |
+| 1_R-MLO      |  0.9308          |  1                |
+| 2_L-CC       |  0.0227          |  0                |
+| 2_R-CC       |  0.0603          |  0                |
+| 2_L-MLO      |  0.0093          |  0                |
+| 2_R-MLO      |  0.0231          |  0                |
+| 3_L-CC       |  0.9326          |  1                |
+| 3_R-CC       |  0.1603          |  0                |
+| 3_L-MLO      |  0.7496          |  1                |
+| 3_R-MLO      |  0.0507          |  0                |
 
 If you model outputs breast-level predictions, it should include the following columns and be saved as a csv.
 
@@ -176,7 +177,7 @@ Breast-level prediction
 
 ## FAQ
 ### Which models are currently available in the metarepository?
-* Breast Cancer Classifier:
+* DMV-CNN:
     * breast-level (`nyu_model`)
     * image-level (`nyu_model_single`)
     * [Paper](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8861376)
@@ -211,7 +212,7 @@ Please keep in mind that below results are shown only for reproduction purposes.
 
 ##### Image level:
 
-| Model | ROC AUC  | PR AUC |
+| Model             | AUROC | AUPRC |
 | ----------------- | ----- | ----- |
 | nyu_glam          | 0.7   | 0.451 |
 | nyu_gmic          | 0.867 | 0.851 |
@@ -222,7 +223,7 @@ Please keep in mind that below results are shown only for reproduction purposes.
 
 ##### Breast level:
 
-| Model | ROC AUC  | PR AUC |
+| Model             | AUROC | AUPRC |
 | ----------------- | ----- | ----- |
 | nyu_glam          | 0.733 | 0.461 |
 | nyu_gmic          | 0.867 | 0.85  |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ In addition to these three things, you may also include a help directory, which 
 
 Your model should work with the sample data provided and `run.sh`. If your model generates image-level predictions, it should include the following columns and be saved as a csv file.
 
-Image-level prediction
+_Image-level predictions_
 
 | image_index  |  malignant_pred  |  malignant_label  |
 | ------------ | ---------------- | ----------------- |
@@ -163,9 +163,9 @@ Image-level prediction
 | 3_L-MLO      |  0.7496          |  1                |
 | 3_R-MLO      |  0.0507          |  0                |
 
-If you model outputs breast-level predictions, it should include the following columns and be saved as a csv.
+If your model outputs breast-level predictions, it should include the following columns and be saved as a csv.
 
-Breast-level prediction
+_Breast-level predictions_
 
 | index | left_malignant | right_malignant |
 | ----- | -------------- | --------------- |
@@ -204,7 +204,7 @@ The following two metrics will be computed and outputted to the terminal:
   * [AUC ROC (area under the receiver operating characteristic curve)](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html)
   * [AUC PR (area under the precision-recall curve)](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_curve.html)
   
-In addition to the above metrics, the metarepository will also generate plots for precision-recall curves and ROC curves at both the image- (if applicable) and breast-levels. The locations of these images will be outputted to the terminal along with the metrics. Also, we provide 95% confidence intervals calculated by bootstrapping with 2,000 replicates.
+In addition to the above metrics, the metarepository will also generate plots for precision-recall curves and ROC curves at both the image (if applicable) and breast-levels. The locations of these images will be outputted to the terminal along with the metrics. Also, we provide 95% confidence intervals calculated by bootstrapping with 2,000 replicates.
 
 ### What results should be expected on the sample images with the supported models?
 

--- a/models/nyu_model/README.md
+++ b/models/nyu_model/README.md
@@ -1,4 +1,4 @@
-### NYU Multiview Model 
+### NYU DMV-CNN
 
 * The original repository is available here: https://github.com/nyukat/breast_cancer_classifier
 * The model uses all 4 views typically found in a mammography exam: left craniocaudal (L-CC), right cranniocaudal (R-CC), left mediolateral oblique (L-MLO), right mediolateral oblique (R-MLO). It generates two sets of predictions, one for each breast. Each set of predictions has a probability that the breast contains a benign lesion and a probability that the breast contains a malignant lesion.

--- a/models/nyu_model_single/README.md
+++ b/models/nyu_model_single/README.md
@@ -1,6 +1,6 @@
-### NYU Multiview Model - Single 
-* This is a special instance of the NYU Multiview Model that is able to operate on single images.
-* It has the same hyper parameters as NYU Multiview Model
+### NYU DMV-CNN - Single 
+* This is a special instance of the DMV-CNN model that is able to operate on single images.
+* It has the same hyper parameters as DMV-CNN model
     * `HEATMAP_BATCH_SIZE` - controls the minibatch size used when generating heatmaps.
     * `NUM_EPOCHS` - controls the number of epochs over validation set (with different preprocessing seeds) to be averaged in the output of the classifiers.
     * `USE_HEATMAPS` - controls whether to use heatmaps or not. If using heatmaps, the process consists of two steps: first a deep network is ran on all 256x256 patches from the main image to generate two heatmaps (one for malignancy, one for benignity). Then, a shallower network is used on the full resolution concatenation of the input image and two heatmaps. If not using heatmaps, the shallower network is used on the input images only.


### PR DESCRIPTION
Minor fixes to README in the main directory as well as dmv-cnn model subdirectories. Changes "NYU Multiview" model naming convention to "DMV-CNN" so that it's consistent with publications.